### PR TITLE
Adds CNAME file to preserve custom domain setting

### DIFF
--- a/webroot/CNAME
+++ b/webroot/CNAME
@@ -1,0 +1,1 @@
+ux.redhat.com


### PR DESCRIPTION
I believe this will fix an issue where the custom domain gets removed on publish to Github Pages.

Per the [docs](https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/troubleshooting-custom-domains-and-github-pages):

> For your site to render at the correct domain, make sure your CNAME file still exists in the repository. For example, many static site generators force push to your repository, which can overwrite the CNAME file that was added to your repository when you configured your custom domain. If you build your site locally and push generated files to GitHub, make sure to pull the commit that added the CNAME file to your local repository first, so the file will be included in the build.

When you manually add the custom domain to the GH page settings it [creates this file in a new commit](https://github.com/RedHat-UX/red-hat-design-system-site/commit/94a92fa4c4f11199727ce01d10f34a5c77e04dcb). I think if we preserve this file in the webroot that's being published it'll preserve the custom domain settings.